### PR TITLE
fix: pin shiki dependency

### DIFF
--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -66,7 +66,7 @@
 				align-items: flex-end;
 			}
 		</style>
-		<script src="https://unpkg.com/shiki"></script>
+		<script src="https://unpkg.com/shiki@0.14.7"></script>
 		<script>
 			let cssCode;
 			let jsCode;


### PR DESCRIPTION
fixes https://github.com/lauthieb/variables-converter-figma-plugin/issues/9

This is more of a temporary fix, until the shiki dependency reaches a stable state. Until then, it's probably not worth the effort migrating it.